### PR TITLE
To get this included in rubygem-unicorn port

### DIFF
--- a/unicorn
+++ b/unicorn
@@ -197,7 +197,7 @@ unicorn_start_command()
   fi
 
   # ensure that the command exists and is executable
-  if [ ! -x ${_chroot}${_chroot:+"/"}${command} ]; then
+  if [ ! -x "${_chroot}${_chroot:+/}${command}" ]; then
     warn "run_rc_command: cannot run $command"
     return 1
   fi


### PR DESCRIPTION
Trying to get your script included in the port, this minor correction is needed to get a correct default behaviour - see http://www.freebsd.org/cgi/query-pr.cgi?pr=ports/184592
